### PR TITLE
Use vectors to store input/output variable names

### DIFF
--- a/heat/bmi_heat.cxx
+++ b/heat/bmi_heat.cxx
@@ -161,15 +161,10 @@ GetGridRank(const int grid)
 int BmiHeat::
 GetGridSize(const int grid)
 {
-  int shape[2];
-
-  if (grid == 0) {
-    this->GetGridShape(grid, shape);
-    return shape[0] * shape[1];
-  }
+  if (grid == 0)
+    return this->_model.shape[0] * this->_model.shape[1];
   else
     return -1;
-
 }
 
 

--- a/heat/bmi_heat.cxx
+++ b/heat/bmi_heat.cxx
@@ -353,19 +353,27 @@ GetOutputItemCount()
 }
 
 
-void BmiHeat::
-GetInputVarNames(std::vector<std::string> &names)
+std::vector<std::string> BmiHeat::
+GetInputVarNames()
 {
+  std::vector<std::string> names;
+
   for (int i=0; i<this->input_var_name_count; i++)
     names.push_back(this->input_var_names[i]);
+
+  return names;
 }
 
 
-void BmiHeat::
-GetOutputVarNames(std::vector<std::string> &names)
+std::vector<std::string> BmiHeat::
+GetOutputVarNames()
 {
+  std::vector<std::string> names;
+
   for (int i=0; i<this->input_var_name_count; i++)
     names.push_back(this->output_var_names[i]);
+
+  return names;
 }
 
 

--- a/heat/bmi_heat.cxx
+++ b/heat/bmi_heat.cxx
@@ -3,6 +3,7 @@
 #include <string>
 #include <cstring>
 #include <cstdlib>
+#include<vector>
 
 #include "bmi_heat.hxx"
 #include "heat.hxx"
@@ -358,20 +359,18 @@ GetOutputItemCount()
 
 
 void BmiHeat::
-GetInputVarNames (char **names)
+GetInputVarNames(std::vector<std::string> &names)
 {
-  for (int i=0; i<this->input_var_name_count; i++) {
-    strncpy(names[i], (const char *)this->input_var_names[i], bmi::MAX_VAR_NAME);
-  }
+  for (int i=0; i<this->input_var_name_count; i++)
+    names.push_back(this->input_var_names[i]);
 }
 
 
 void BmiHeat::
-GetOutputVarNames (char **names)
+GetOutputVarNames(std::vector<std::string> &names)
 {
-  for (int i=0; i<this->input_var_name_count; i++) {
-    strncpy(names[i], (const char *)this->output_var_names[i], bmi::MAX_VAR_NAME);
-  }
+  for (int i=0; i<this->input_var_name_count; i++)
+    names.push_back(this->output_var_names[i]);
 }
 
 

--- a/heat/bmi_heat.hxx
+++ b/heat/bmi_heat.hxx
@@ -29,8 +29,8 @@ class BmiHeat : public bmi::Bmi {
     std::string GetComponentName();
     int GetInputItemCount();
     int GetOutputItemCount();
-    void GetInputVarNames(char **names);
-    void GetOutputVarNames(char **names);
+    void GetInputVarNames(std::vector<std::string> &names);
+    void GetOutputVarNames(std::vector<std::string> &names);
 
     int GetVarGrid(std::string name);
     std::string GetVarType(std::string name);
@@ -78,8 +78,8 @@ class BmiHeat : public bmi::Bmi {
     static const int input_var_name_count = 1;
     static const int output_var_name_count = 1;
 
-    const char* input_var_names[2];
-    const char* output_var_names[2];
+    std::string input_var_names[2];
+    std::string output_var_names[2];
 };
 
 #endif

--- a/heat/bmi_heat.hxx
+++ b/heat/bmi_heat.hxx
@@ -21,7 +21,7 @@ class BmiHeat : public bmi::Bmi {
       this->output_var_names[0] = "plate_surface__temperature";
     };
 
-    void Initialize (std::string config_file);
+    void Initialize(std::string config_file);
     void Update();
     void UpdateUntil(double time);
     void Finalize();
@@ -29,8 +29,8 @@ class BmiHeat : public bmi::Bmi {
     std::string GetComponentName();
     int GetInputItemCount();
     int GetOutputItemCount();
-    void GetInputVarNames(std::vector<std::string> &names);
-    void GetOutputVarNames(std::vector<std::string> &names);
+    std::vector<std::string> GetInputVarNames();
+    std::vector<std::string> GetOutputVarNames();
 
     int GetVarGrid(std::string name);
     std::string GetVarType(std::string name);

--- a/testing/test_grid_info.cxx
+++ b/testing/test_grid_info.cxx
@@ -24,12 +24,12 @@ main (void)
     std::vector<std::string> names;
 
     number_of_names = model.GetInputItemCount();
-    model.GetInputVarNames(names);
+    names = model.GetInputVarNames();
     for (int i=0; i<number_of_names; i++)
       print_var_info(model, names[i]);
 
     number_of_names = model.GetOutputItemCount();
-    model.GetOutputVarNames(names);
+    names = model.GetOutputVarNames();
     for (int i=0; i<number_of_names; i++)
       print_var_info(model, names[i]);
   }

--- a/testing/test_grid_info.cxx
+++ b/testing/test_grid_info.cxx
@@ -3,9 +3,10 @@
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
 
 
-void print_var_info (BmiHeat model, char *var);
+void print_var_info (BmiHeat model, std::string var);
 
 int
 main (void)
@@ -20,28 +21,17 @@ main (void)
 
   {
     int number_of_names;
-    char **names;
+    std::vector<std::string> names;
 
     number_of_names = model.GetInputItemCount();
-    names = new char*[number_of_names];
-    for (int i=0; i<number_of_names; i++) {
-      names[i] = new char[bmi::MAX_VAR_NAME];
-    }
-
     model.GetInputVarNames(names);
     for (int i=0; i<number_of_names; i++)
       print_var_info(model, names[i]);
 
     number_of_names = model.GetOutputItemCount();
-    names = new char*[number_of_names];
-    for (int i=0; i<number_of_names; i++) {
-      names[i] = new char[bmi::MAX_VAR_NAME];
-    }
-
     model.GetOutputVarNames(names);
     for (int i=0; i<number_of_names; i++)
       print_var_info(model, names[i]);
-
   }
 
   model.Finalize();
@@ -50,7 +40,7 @@ main (void)
 }
 
 void
-print_var_info(BmiHeat model, char *var)
+print_var_info(BmiHeat model, std::string var)
 {
   int *shape;
   double *spacing;
@@ -82,7 +72,7 @@ print_var_info(BmiHeat model, char *var)
   fprintf (stdout, "\n");
   fprintf (stdout, "Variable info\n");
   fprintf (stdout, "=============\n");
-  fprintf (stdout, "Name: %s\n", var);
+  fprintf (stdout, "Name: %s\n", var.c_str());
   fprintf (stdout, "Type: %s\n", type.c_str());
   fprintf (stdout, "Units: %s\n", units.c_str());
   fprintf (stdout, "Rank: %d\n", rank);

--- a/testing/test_print_var_names.cxx
+++ b/testing/test_print_var_names.cxx
@@ -36,14 +36,14 @@ print_var_names (BmiHeat model)
 
   number_of_names = model.GetInputItemCount();
   fprintf (stdout, "Number of input names: %d\n", number_of_names);
-  model.GetInputVarNames(names);
+  names = model.GetInputVarNames();
   for (int i=0; i<number_of_names; i++)
     fprintf (stdout, "%s\n", names[i].c_str());
   fprintf (stdout, "\n");
 
   number_of_names = model.GetOutputItemCount();
   fprintf (stdout, "Number of output names: %d\n", number_of_names);
-  model.GetOutputVarNames(names);
+  names = model.GetOutputVarNames();
   for (int i=0; i<number_of_names; i++)
     fprintf (stdout, "%s\n", names[i].c_str());
   fprintf (stdout, "\n");

--- a/testing/test_print_var_names.cxx
+++ b/testing/test_print_var_names.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
+
 
 void print_var_names (BmiHeat model);
 
@@ -29,32 +31,20 @@ main (void)
 void
 print_var_names (BmiHeat model)
 {
-  char **names;
   int number_of_names;
+  std::vector<std::string> names;
 
   number_of_names = model.GetInputItemCount();
   fprintf (stdout, "Number of input names: %d\n", number_of_names);
-
-  names = new char*[number_of_names];
-  for (int i=0; i<number_of_names; i++) {
-    names[i] = new char[bmi::MAX_VAR_NAME];
-  }
-
   model.GetInputVarNames(names);
   for (int i=0; i<number_of_names; i++)
-    fprintf (stdout, "%s\n", names[i]);
+    fprintf (stdout, "%s\n", names[i].c_str());
   fprintf (stdout, "\n");
 
   number_of_names = model.GetOutputItemCount();
   fprintf (stdout, "Number of output names: %d\n", number_of_names);
-
-  names = new char*[number_of_names];
-  for (int i=0; i<number_of_names; i++) {
-    names[i] = new char[bmi::MAX_VAR_NAME];
-  }
-
   model.GetOutputVarNames(names);
   for (int i=0; i<number_of_names; i++)
-    fprintf (stdout, "%s\n", names[i]);
+    fprintf (stdout, "%s\n", names[i].c_str());
   fprintf (stdout, "\n");
 }


### PR DESCRIPTION
This PR updates the BMI implementation of the Heat model to use vectors for the GetInputVarNames and GetOutputVarNames methods. See https://github.com/csdms/bmi-cxx/pull/5 for arguments for and against this approach.

The PR also includes an update to the GetGridShape method: I had violated a cardinal rule of not allocating memory in a BMI method. 