### PR TITLE
Fix imports on Linux

### DIFF
--- a/heat/bmi_main.cxx
+++ b/heat/bmi_main.cxx
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
+#include <vector>
 
 #include "bmi_heat.hxx"
 

--- a/testing/test_conflicting_instances.cxx
+++ b/testing/test_conflicting_instances.cxx
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <iostream>
+#include <vector>
 
 #include <bmi_heat.hxx>
 

--- a/testing/test_get_value.cxx
+++ b/testing/test_get_value.cxx
@@ -1,8 +1,9 @@
-#include <bmi_heat.hxx>
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
+
+#include <bmi_heat.hxx>
 
 
 void print_var_values(BmiHeat model, const char *var_name);

--- a/testing/test_grid_info.cxx
+++ b/testing/test_grid_info.cxx
@@ -1,9 +1,9 @@
-#include "bmi_heat.hxx"
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
+
+#include "bmi_heat.hxx"
 
 
 void print_var_info (BmiHeat model, std::string var);

--- a/testing/test_initialize_from_file.cxx
+++ b/testing/test_initialize_from_file.cxx
@@ -1,8 +1,9 @@
-#include <bmi_heat.hxx>
-
-#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <iostream>
+#include <vector>
+
+#include <bmi_heat.hxx>
 
 int
 main (void)

--- a/testing/test_irf.cxx
+++ b/testing/test_irf.cxx
@@ -1,8 +1,10 @@
-#include <bmi_heat.hxx>
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
+
+#include <bmi_heat.hxx>
+
 
 int
 main (void)

--- a/testing/test_print_var_names.cxx
+++ b/testing/test_print_var_names.cxx
@@ -1,9 +1,9 @@
-#include <bmi_heat.hxx>
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <vector>
+
+#include <bmi_heat.hxx>
 
 
 void print_var_names (BmiHeat model);

--- a/testing/test_reinitialize.cxx
+++ b/testing/test_reinitialize.cxx
@@ -1,8 +1,10 @@
-#include <bmi_heat.hxx>
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
+
+#include <bmi_heat.hxx>
+
 
 int
 main (void)

--- a/testing/test_set_value.cxx
+++ b/testing/test_set_value.cxx
@@ -1,8 +1,10 @@
-#include <bmi_heat.hxx>
-
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
+
+#include <bmi_heat.hxx>
+
 
 void print_matrix (double *m, int n_dims, int * shape);
 


### PR DESCRIPTION
While `vector` doesn't have to be explicitly imported on macOS, it does on Linux. This PR adds the missing imports.