### PR TITLE
Test header guards on heat.hxx, bmi.hxx, and bmi_heat.hxx

### DIFF
--- a/heat/bmi_heat.cxx
+++ b/heat/bmi_heat.cxx
@@ -5,8 +5,9 @@
 #include <cstdlib>
 #include<vector>
 
-#include "bmi_heat.hxx"
 #include "heat.hxx"
+#include <bmi.hxx>
+#include "bmi_heat.hxx"
 
 
 void BmiHeat::

--- a/heat/bmi_main.cxx
+++ b/heat/bmi_main.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <vector>
 
+#include "heat.hxx"
+#include <bmi.hxx>
 #include "bmi_heat.hxx"
 
 

--- a/testing/test_conflicting_instances.cxx
+++ b/testing/test_conflicting_instances.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 

--- a/testing/test_get_value.cxx
+++ b/testing/test_get_value.cxx
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 

--- a/testing/test_grid_info.cxx
+++ b/testing/test_grid_info.cxx
@@ -3,7 +3,9 @@
 #include <stdlib.h>
 #include <vector>
 
-#include "bmi_heat.hxx"
+#include <heat.hxx>
+#include <bmi.hxx>
+#include <bmi_heat.hxx>
 
 
 void print_var_info (BmiHeat model, std::string var);

--- a/testing/test_initialize_from_file.cxx
+++ b/testing/test_initialize_from_file.cxx
@@ -3,6 +3,8 @@
 #include <iostream>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 int

--- a/testing/test_irf.cxx
+++ b/testing/test_irf.cxx
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 

--- a/testing/test_print_var_names.cxx
+++ b/testing/test_print_var_names.cxx
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 

--- a/testing/test_reinitialize.cxx
+++ b/testing/test_reinitialize.cxx
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 

--- a/testing/test_set_value.cxx
+++ b/testing/test_set_value.cxx
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <vector>
 
+#include <heat.hxx>
+#include <bmi.hxx>
 #include <bmi_heat.hxx>
 
 


### PR DESCRIPTION
The guards prevent multiple includes.