### PR TITLE
Standardize diffusion model

### DIFF
--- a/heat/bmi_heat.cxx
+++ b/heat/bmi_heat.cxx
@@ -90,7 +90,7 @@ std::string BmiHeat::
 GetVarUnits(std::string name)
 {
   if (name.compare("plate_surface__temperature") == 0)
-    return "meters";
+    return "K";
   else
     return "";
 }

--- a/heat/heat.cxx
+++ b/heat/heat.cxx
@@ -112,7 +112,7 @@ _initialize_arrays(void)
   }
   for (i = 0; i < n_x; i++) {
     this->z[0][i] = 0.;
-    this->z[n_y-1][i] = top_x*top_x*.25 - (i-top_x*.5) * (i-top_x*.5);
+    this->z[n_y-1][i] = 0.;
   }
 
   memcpy (this->temp_z[0], this->z[0], sizeof (double)*n_x*n_y);


### PR DESCRIPTION
This PR is part of an attempt to standardize the diffusion model used in all four BMI examples. The model:

* uses a 2D uniform rectilinear grid
* has a random initial field
* has Dirichlet boundary conditions set to zero (temperature not conserved)
* uses a time step defined by a stability criterion: `dt = min(spacing)^2 / (4 * alpha)` 