### PR TITLE
Updates to source and build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(bmi_name bmi${model_name})
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(BMICXX REQUIRED IMPORTED_TARGET bmicxx)
 message("--   bmicxx include dir - ${BMICXX_INCLUDE_DIRS}")
-include_directories(${BMICXX_INCLUDE_DIRS})
 
 add_subdirectory(heat)
 add_subdirectory(testing)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # bmi-example-cxx
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.16)
 project(bmi-example-cxx
     VERSION 2.1.2
     LANGUAGES CXX
@@ -13,7 +13,9 @@ set(bmi_name bmi${model_name})
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(BMICXX REQUIRED IMPORTED_TARGET bmicxx)
-message("--   bmicxx include dir - ${BMICXX_INCLUDE_DIRS}")
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+message(STATUS "Include directory: ${BMICXX_INCLUDE_DIRS}")
+list(POP_BACK CMAKE_MESSAGE_INDENT)
 
 add_subdirectory(heat)
 add_subdirectory(testing)

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -16,10 +16,10 @@ else()
   add_library(${model_name} SHARED heat.cxx)
   add_library(${bmi_name} SHARED bmi_heat.cxx heat.cxx)
 endif()
+target_include_directories(${bmi_name} PUBLIC ${BMICXX_INCLUDE_DIRS})
 
 add_executable(run_${bmi_name} bmi_main.cxx)
 target_link_libraries(run_${bmi_name} ${bmi_name})
-target_include_directories(run_${bmi_name} PUBLIC ${BMICXX_INCLUDE_DIRS})
 
 install(
   TARGETS run_${bmi_name}

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 add_executable(run_${bmi_name} bmi_main.cxx)
 target_link_libraries(run_${bmi_name} ${bmi_name})
+target_include_directories(run_${bmi_name} PUBLIC ${BMICXX_INCLUDE_DIRS})
 
 install(
   TARGETS run_${bmi_name}

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -17,7 +17,8 @@ else()
   add_library(${bmi_name} SHARED bmi_heat.cxx heat.cxx)
 endif()
 
-add_executable(run_${bmi_name} bmi_main.cxx bmi_heat.cxx heat.cxx)
+add_executable(run_${bmi_name} bmi_main.cxx)
+target_link_libraries(run_${bmi_name} ${bmi_name})
 
 install(
   TARGETS run_${bmi_name}

--- a/heat/bmi_heat.cxx
+++ b/heat/bmi_heat.cxx
@@ -3,7 +3,7 @@
 #include <string>
 #include <cstring>
 #include <cstdlib>
-#include<vector>
+#include <vector>
 
 #include "heat.hxx"
 #include <bmi.hxx>

--- a/heat/bmi_heat.hxx
+++ b/heat/bmi_heat.hxx
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <iostream>
+#include <vector>
 
 #include <bmi.hxx>
 #include "heat.hxx"


### PR DESCRIPTION
This PR collects a few minor improvements to the project:

1. Supply a missing include to _vector_ in `bmi_heat.cxx`. I hadn't caught this before, but it popped up when I built the project recently with a newer version of _gcc_.
2. Link the executable example program `run_bmiheatcxx` against the _bmiheatcxx_ library instead of reusing source code to build it.
3. Use the CMake `target_include_directories` function instead of the obsolete `include_directories` function, and apply it when building the _bmiheatcxx_ library.
4. Bump the minimum CMake version to support better status messages.