### PR TITLE
Set model start time when initializing from config file

### DIFF
--- a/heat/heat.cxx
+++ b/heat/heat.cxx
@@ -73,6 +73,7 @@ Heat(std::string config_file)
   this->alpha = alpha;
   this->dt = 1. / (4. * alpha);
   this->t_end = t_end;
+  this->time = 0.;
   this->shape[0] = n_y;
   this->shape[1] = n_x;
   this->spacing[0] = 1.;

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -18,6 +18,7 @@ make_test(test_grid_info)
 make_test(test_initialize_from_file)
 make_test(test_reinitialize)
 make_test(test_conflicting_instances)
+make_test(test_time)
 
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/config.txt

--- a/testing/test_time.cxx
+++ b/testing/test_time.cxx
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <stdlib.h>
+#include <vector>
+#include <assert.h>
+#include <math.h>
+
+#include <heat.hxx>
+#include <bmi.hxx>
+#include <bmi_heat.hxx>
+
+
+int
+main(void)
+{
+  BmiHeat model;
+  double time_expected = 0.0;
+  double tolerance = 0.01;
+
+  {
+    double time;
+
+    model.Initialize("");
+    fprintf(stdout, "Model initialized\n");
+    time = model.GetCurrentTime();
+    model.Finalize();
+    fprintf(stdout, "Model finalized\n");
+
+    fprintf(stdout, "time = %f\n", time);
+    assert(fabs(time - time_expected) <= tolerance && "Unexpected current time value");
+  }
+
+  {
+    double time;
+
+    model.Initialize("config.txt");
+    fprintf(stdout, "Model initialized\n");
+    time = model.GetCurrentTime();
+    model.Finalize();
+    fprintf(stdout, "Model finalized\n");
+
+    fprintf(stdout, "time = %f\n", time);
+    assert(fabs(time - time_expected) <= tolerance && "Unexpected current time value");
+  }
+}


### PR DESCRIPTION
This PR sets the time attribute in the constructor when the example model is initialized from a configuration file. Previously, it was not defined.

This was an interesting problem. I hadn't run into it before recently when I started building the example model through Docker. Even then, the current set of unit tests didn't catch it. I only found it when I ran the `run_bmiheatcxx` executable.

So, there was no issue when building from source on macOS (amd64 or arm64), Linux (amd64 or aarch64) and Windows, but it failed when building through Docker on my macOS arm64 laptop. Weird!

I included a new test to catch this problem.